### PR TITLE
Add -f/--file parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- -C/--unmerge flag
+- -C/--unmerge flag: unmerge package before each test
+- -f/--file flag: read from ebuild file and temporary inject its hosting repository
 
 ## [0.2.2] - 2024-02-17
 

--- a/pkg_testing_tools/job.py
+++ b/pkg_testing_tools/job.py
@@ -1,0 +1,128 @@
+import argparse
+import datetime
+import json
+import os
+import shlex
+import subprocess
+import sys
+from contextlib import ExitStack
+from tempfile import NamedTemporaryFile
+
+import portage
+
+from .log import edebug, edie, eerror, einfo
+from .use import atom_to_cpv, get_package_flags, get_use_combinations
+
+
+def get_package_metadata(atom):
+    # This handles revisions properly, but not live ebuilds: https://bugs.gentoo.org/918693 https://github.com/APN-Pucky/pkg-testing-tools/issues/10
+    cpv = atom_to_cpv(atom)
+    # cpv is None on missing/masked packages
+    if cpv:
+        edebug(f"cpv through match(): {cpv}")
+    else:
+        edebug(f"could not find unmasked package {atom}, assuming it is available")
+        # This handles live ebuilds properly, but not revisions: https://bugs.gentoo.org/918693 https://github.com/APN-Pucky/pkg-testing-tools/issues/10
+        cpv = portage.dep.dep_getcpv(atom)
+        edebug(f"cpv through dep_getcpv(): {cpv}")
+
+    cp, version, revision = portage.versions.pkgsplit(cpv)
+
+    iuse, ruse = get_package_flags(cpv)
+
+    phases = portage.portdb.aux_get(cpv, ["DEFINED_PHASES"])[0].split()
+
+    return {
+        "atom": atom,
+        "cp": cp,
+        "cpv": cpv,
+        "version": version,
+        "revision": revision,
+        "has_tests": ("test" in phases),
+        "iuse": iuse,
+        "ruse": ruse,
+    }
+
+
+def define_jobs(atom, args):
+    jobs = []
+
+    package_metadata = get_package_metadata(atom)
+
+    common = {
+        "cpv": atom,
+        "cp": package_metadata["cp"],
+        "extra_env_files": (
+            " ".join(args.extra_env_file) if args.extra_env_file else []
+        ),
+    }
+
+    if args.debug:
+        edebug("{}".format(common))
+        edebug("{}".format(package_metadata))
+
+    if args.append_required_use:
+        package_metadata["ruse"].append(args.append_required_use)
+
+    if package_metadata["iuse"] and args.max_use_combinations > 1:
+        use_combinations = get_use_combinations(
+            package_metadata["iuse"],
+            package_metadata["ruse"],
+            args.max_use_combinations,
+        )
+    else:
+        use_combinations = None
+
+    if use_combinations:
+        if package_metadata["has_tests"] and args.test_feature_scope == "always":
+            test_feature_toggle = True
+        else:
+            test_feature_toggle = False
+
+        for flags_set in use_combinations:
+            job = {}
+            job.update(common)
+            job.update(
+                {
+                    "test_feature_toggle": test_feature_toggle,
+                    "use_flags": flags_set,
+                    "use_flags_scope": args.use_flags_scope,
+                }
+            )
+            jobs.append(job)
+
+        if package_metadata["has_tests"] and args.test_feature_scope == "once":
+            job = {}
+            job.update(common)
+            job.update(
+                {
+                    "test_feature_toggle": True,
+                    "use_flags": [],
+                    "use_flags_scope": args.use_flags_scope,
+                }
+            )
+            jobs.append(job)
+    else:
+        if not package_metadata["has_tests"] or args.test_feature_scope == "never":
+            job = {}
+            job.update(common)
+            job.update(
+                {
+                    "test_feature_toggle": False,
+                    "use_flags": [],
+                    "use_flags_scope": args.use_flags_scope,
+                }
+            )
+            jobs.append(job)
+        else:
+            job = {}
+            job.update(common)
+            job.update({"test_feature_toggle": False, "use_flags": []})
+            jobs.append(job)
+
+            job = {}
+            job.update(common)
+            job.update({"test_feature_toggle": True, "use_flags": []})
+            jobs.append(job)
+
+    return jobs

--- a/pkg_testing_tools/log.py
+++ b/pkg_testing_tools/log.py
@@ -1,0 +1,18 @@
+import sys
+
+
+def eerror(msg):
+    print("[ERROR] >>> {}".format(msg))
+
+
+def einfo(msg):
+    print("[INFO] >>> {}".format(msg))
+
+
+def edebug(msg):
+    print("[DEBUG] >>> {}".format(msg))
+
+
+def edie(msg):
+    eerror(msg)
+    sys.exit(1)

--- a/pkg_testing_tools/main.py
+++ b/pkg_testing_tools/main.py
@@ -182,14 +182,23 @@ def pkg_testing_tool(args, extra_args):
                 get_etc_portage_tmp_file(directory, args.prefix)
             )
 
-        if args.repo:
+        for ebuild in args.file:
+            # test that file ends in ".ebuild"
+            if not ebuild.endswith(".ebuild"):
+                edie("File {} does not end with '.ebuild'.".format(ebuild))
+            repo = os.path.dirname(os.path.dirname(os.path.abspath(ebuild)))
             # read repo_name from repo profiles/repo_name
             repo_name = "zzzpkgtestingtool"
-            with open(os.path.join(args.repo, "profiles/repo_name"), "r") as f:
+            with open(os.path.join(repo, "profiles/repo_name"), "r") as f:
                 repo_name = f.read().strip()
             tmp_files["repos.conf"].write(
-                f"[{repo_name}]\npriority=9999\nlocation = {args.repo}\n"
+                f"[{repo_name}]\npriority=9999\nlocation = {repo}\n"
             )
+            # ebuild to category/package-X.Y.Z
+            # get parent directory name of ebuild
+            category = os.path.basename(os.path.dirname(os.path.abspath(ebuild)))
+            package_version = os.path.basename(ebuild).replace(".ebuild", "")
+            args.package_atom += ["=" + category + "/" + package_version]
 
         jobs = []
 

--- a/pkg_testing_tools/main.py
+++ b/pkg_testing_tools/main.py
@@ -10,26 +10,11 @@ from tempfile import NamedTemporaryFile
 
 import portage
 
+from .job import define_jobs, get_package_metadata
+from .log import edebug, edie, eerror, einfo
+from .test import run_testing
+from .tmp import get_etc_portage_tmp_file
 from .use import atom_to_cpv, get_package_flags, get_use_combinations
-
-
-def get_etc_portage_tmp_file(directory_name, prefix):
-    target_location = os.path.join(prefix + "/etc/portage", directory_name)
-
-    if not os.path.isdir(target_location):
-        edie(
-            "The location {} needs to exist and be a directory".format(target_location)
-        )
-
-    handler = NamedTemporaryFile(
-        mode="w", prefix="zzz_pkg_testing_tool_", dir=target_location
-    )
-
-    umask = os.umask(0)
-    os.umask(umask)
-    os.chmod(handler.name, 0o644 & ~umask)
-
-    return handler
 
 
 def process_args():
@@ -166,247 +151,6 @@ def process_args():
     return args, extra_args
 
 
-def eerror(msg):
-    print("[ERROR] >>> {}".format(msg))
-
-
-def einfo(msg):
-    print("[INFO] >>> {}".format(msg))
-
-
-def edebug(msg):
-    print("[DEBUG] >>> {}".format(msg))
-
-
-def edie(msg):
-    eerror(msg)
-    sys.exit(1)
-
-
-def get_package_metadata(atom):
-    # This handles revisions properly, but not live ebuilds: https://bugs.gentoo.org/918693 https://github.com/APN-Pucky/pkg-testing-tools/issues/10
-    cpv = atom_to_cpv(atom)
-    # cpv is None on missing/masked packages
-    if cpv:
-        edebug(f"cpv through match(): {cpv}")
-    else:
-        edebug(f"could not find unmasked package {atom}, assuming it is available")
-        # This handles live ebuilds properly, but not revisions: https://bugs.gentoo.org/918693 https://github.com/APN-Pucky/pkg-testing-tools/issues/10
-        cpv = portage.dep.dep_getcpv(atom)
-        edebug(f"cpv through dep_getcpv(): {cpv}")
-
-    cp, version, revision = portage.versions.pkgsplit(cpv)
-
-    iuse, ruse = get_package_flags(cpv)
-
-    phases = portage.portdb.aux_get(cpv, ["DEFINED_PHASES"])[0].split()
-
-    return {
-        "atom": atom,
-        "cp": cp,
-        "cpv": cpv,
-        "version": version,
-        "revision": revision,
-        "has_tests": ("test" in phases),
-        "iuse": iuse,
-        "ruse": ruse,
-    }
-
-
-def run_testing(job, args):
-    global_features = []
-
-    time_started = datetime.datetime.now().replace(microsecond=0).isoformat()
-
-    emerge_cmdline = [
-        "emerge",
-        "--verbose",
-        "y",
-        "--usepkg-exclude",
-        job["cp"],
-        "--deep",
-        "--backtrack",
-        "300",
-    ]
-    unmerge_cmdline = [
-        "emerge",
-        "--rage-clean",
-        job["cp"],
-    ]
-
-    if args.append_emerge:
-        emerge_cmdline += shlex.split(args.append_emerge)
-
-    if args.binpkg:
-        emerge_cmdline.append("--usepkg")
-        global_features.append("buildpkg")
-
-    if args.ccache:
-        if not portage.settings.get("CCACHE_DIR") or not portage.settings.get(
-            "CCACHE_SIZE"
-        ):
-            eerror("The CCACHE_DIR and/or CCACHE_SIZE is not set!")
-            sys.exit(1)
-
-        global_features.append("ccache")
-
-    emerge_cmdline.append(job["cpv"])
-
-    with ExitStack() as stack:
-        tmp_files = {}
-
-        for directory in ["env", "package.env", "package.use"]:
-            tmp_files[directory] = stack.enter_context(
-                get_etc_portage_tmp_file(directory, args.prefix)
-            )
-
-        tested_cpv_features = ["qa-unresolved-soname-deps", "multilib-strict"]
-
-        if job["test_feature_toggle"]:
-            tested_cpv_features.append("test")
-
-        if tested_cpv_features:
-            tmp_files["env"].write(
-                'FEATURES="{}"\n'.format(" ".join(tested_cpv_features))
-            )
-
-        env_files = [os.path.basename(tmp_files["env"].name)]
-
-        if job["extra_env_files"]:
-            env_files.append(job["extra_env_files"])
-
-        tmp_files["package.env"].write(
-            "{cp} {env_files}\n".format(cp=job["cp"], env_files=" ".join(env_files))
-        )
-
-        if job["use_flags"]:
-            tmp_files["package.use"].write(
-                "{prefix} {flags}\n".format(
-                    prefix=(
-                        "*/*" if job["use_flags_scope"] == "global" else job["cpv"]
-                    ),
-                    flags=" ".join(job["use_flags"]),
-                )
-            )
-
-        for handler in tmp_files:
-            tmp_files[handler].flush()
-
-        env = os.environ.copy()
-
-        if global_features:
-            if "FEATURES" in env:
-                env["FEATURES"] = "{} {}".format(
-                    env["FEATURES"], " ".join(global_features)
-                )
-            else:
-                env["FEATURES"] = " ".join(global_features)
-
-        if args.unmerge:
-            subprocess.run(unmerge_cmdline, env=env)
-
-        emerge_result = subprocess.run(emerge_cmdline, env=env)
-        print("")
-
-    return {
-        "use_flags": " ".join(job["use_flags"]),
-        "exit_code": emerge_result.returncode,
-        "features": portage.settings.get("FEATURES"),
-        "emerge_default_opts": portage.settings.get("EMERGE_DEFAULT_OPTS"),
-        "emerge_cmdline": " ".join(emerge_cmdline),
-        "test_feature_toggle": job["test_feature_toggle"],
-        "atom": job["cpv"],
-        "time": {
-            "started": time_started,
-            "finished": datetime.datetime.now().replace(microsecond=0).isoformat(),
-        },
-    }
-
-
-def define_jobs(atom, args):
-    jobs = []
-
-    package_metadata = get_package_metadata(atom)
-
-    common = {
-        "cpv": atom,
-        "cp": package_metadata["cp"],
-        "extra_env_files": (
-            " ".join(args.extra_env_file) if args.extra_env_file else []
-        ),
-    }
-
-    if args.debug:
-        edebug("{}".format(common))
-        edebug("{}".format(package_metadata))
-
-    if args.append_required_use:
-        package_metadata["ruse"].append(args.append_required_use)
-
-    if package_metadata["iuse"] and args.max_use_combinations > 1:
-        use_combinations = get_use_combinations(
-            package_metadata["iuse"],
-            package_metadata["ruse"],
-            args.max_use_combinations,
-        )
-    else:
-        use_combinations = None
-
-    if use_combinations:
-        if package_metadata["has_tests"] and args.test_feature_scope == "always":
-            test_feature_toggle = True
-        else:
-            test_feature_toggle = False
-
-        for flags_set in use_combinations:
-            job = {}
-            job.update(common)
-            job.update(
-                {
-                    "test_feature_toggle": test_feature_toggle,
-                    "use_flags": flags_set,
-                    "use_flags_scope": args.use_flags_scope,
-                }
-            )
-            jobs.append(job)
-
-        if package_metadata["has_tests"] and args.test_feature_scope == "once":
-            job = {}
-            job.update(common)
-            job.update(
-                {
-                    "test_feature_toggle": True,
-                    "use_flags": [],
-                    "use_flags_scope": args.use_flags_scope,
-                }
-            )
-            jobs.append(job)
-    else:
-        if not package_metadata["has_tests"] or args.test_feature_scope == "never":
-            job = {}
-            job.update(common)
-            job.update(
-                {
-                    "test_feature_toggle": False,
-                    "use_flags": [],
-                    "use_flags_scope": args.use_flags_scope,
-                }
-            )
-            jobs.append(job)
-        else:
-            job = {}
-            job.update(common)
-            job.update({"test_feature_toggle": False, "use_flags": []})
-            jobs.append(job)
-
-            job = {}
-            job.update(common)
-            job.update({"test_feature_toggle": True, "use_flags": []})
-            jobs.append(job)
-
-    return jobs
-
-
 def yes_no(question):
     reply = input(question).lower()
 
@@ -424,9 +168,18 @@ def pkg_testing_tool(args, extra_args):
     with ExitStack() as stack:
         tmp_files = {}
 
-        for directory in ["package.accept_keywords", "package.unmask"]:
+        for directory in ["package.accept_keywords", "package.unmask", "repos.conf"]:
             tmp_files[directory] = stack.enter_context(
                 get_etc_portage_tmp_file(directory, args.prefix)
+            )
+
+        if args.repo:
+            # read repo_name from repo profiles/repo_name
+            repo_name = "zzzpkgtestingtool"
+            with open(os.path.join(args.repo, "profiles/repo_name"), "r") as f:
+                repo_name = f.read().strip()
+            tmp_files["repos.conf"].write(
+                f"[{repo_name}]\npriority=9999\nlocation = {args.repo}\n"
             )
 
         jobs = []

--- a/pkg_testing_tools/main.py
+++ b/pkg_testing_tools/main.py
@@ -20,14 +20,23 @@ from .use import atom_to_cpv, get_package_flags, get_use_combinations
 def process_args():
     parser = argparse.ArgumentParser()
 
-    required = parser.add_argument_group("Required")
+    # required = parser.add_argument_group("Required")
+    group = parser.add_mutually_exclusive_group(required=True)
 
-    required.add_argument(
+    group.add_argument(
         "-p",
         "--package-atom",
         action="append",
         required=True,
         help="Valid Portage package atom, like '=app-category/foo-1.2.3'. Can be specified multiple times to unmask/keyword all of them and test them one by one.",
+    )
+
+    group.add_argument(
+        "-f",
+        "--file",
+        action="append",
+        required=True,
+        help="Portage ebuild file like 'foo-1.2.3.ebuild'. Must reside in a repository.",
     )
 
     optional = parser.add_argument_group("Optional")

--- a/pkg_testing_tools/test.py
+++ b/pkg_testing_tools/test.py
@@ -9,7 +9,7 @@ from contextlib import ExitStack
 
 import portage
 
-from .log import eerror
+from .log import edie, eerror
 from .tmp import get_etc_portage_tmp_file
 
 
@@ -45,8 +45,7 @@ def run_testing(job, args):
         if not portage.settings.get("CCACHE_DIR") or not portage.settings.get(
             "CCACHE_SIZE"
         ):
-            eerror("The CCACHE_DIR and/or CCACHE_SIZE is not set!")
-            sys.exit(1)
+            edie("The CCACHE_DIR and/or CCACHE_SIZE is not set!")
 
         global_features.append("ccache")
 

--- a/pkg_testing_tools/test.py
+++ b/pkg_testing_tools/test.py
@@ -1,0 +1,123 @@
+import argparse
+import datetime
+import json
+import os
+import shlex
+import subprocess
+import sys
+from contextlib import ExitStack
+
+import portage
+
+from .log import eerror
+from .tmp import get_etc_portage_tmp_file
+
+
+def run_testing(job, args):
+    global_features = []
+
+    time_started = datetime.datetime.now().replace(microsecond=0).isoformat()
+
+    emerge_cmdline = [
+        "emerge",
+        "--verbose",
+        "y",
+        "--usepkg-exclude",
+        job["cp"],
+        "--deep",
+        "--backtrack",
+        "300",
+    ]
+    unmerge_cmdline = [
+        "emerge",
+        "--rage-clean",
+        job["cp"],
+    ]
+
+    if args.append_emerge:
+        emerge_cmdline += shlex.split(args.append_emerge)
+
+    if args.binpkg:
+        emerge_cmdline.append("--usepkg")
+        global_features.append("buildpkg")
+
+    if args.ccache:
+        if not portage.settings.get("CCACHE_DIR") or not portage.settings.get(
+            "CCACHE_SIZE"
+        ):
+            eerror("The CCACHE_DIR and/or CCACHE_SIZE is not set!")
+            sys.exit(1)
+
+        global_features.append("ccache")
+
+    emerge_cmdline.append(job["cpv"])
+
+    with ExitStack() as stack:
+        tmp_files = {}
+
+        for directory in ["env", "package.env", "package.use"]:
+            tmp_files[directory] = stack.enter_context(
+                get_etc_portage_tmp_file(directory, args.prefix)
+            )
+
+        tested_cpv_features = ["qa-unresolved-soname-deps", "multilib-strict"]
+
+        if job["test_feature_toggle"]:
+            tested_cpv_features.append("test")
+
+        if tested_cpv_features:
+            tmp_files["env"].write(
+                'FEATURES="{}"\n'.format(" ".join(tested_cpv_features))
+            )
+
+        env_files = [os.path.basename(tmp_files["env"].name)]
+
+        if job["extra_env_files"]:
+            env_files.append(job["extra_env_files"])
+
+        tmp_files["package.env"].write(
+            "{cp} {env_files}\n".format(cp=job["cp"], env_files=" ".join(env_files))
+        )
+
+        if job["use_flags"]:
+            tmp_files["package.use"].write(
+                "{prefix} {flags}\n".format(
+                    prefix=(
+                        "*/*" if job["use_flags_scope"] == "global" else job["cpv"]
+                    ),
+                    flags=" ".join(job["use_flags"]),
+                )
+            )
+
+        for handler in tmp_files:
+            tmp_files[handler].flush()
+
+        env = os.environ.copy()
+
+        if global_features:
+            if "FEATURES" in env:
+                env["FEATURES"] = "{} {}".format(
+                    env["FEATURES"], " ".join(global_features)
+                )
+            else:
+                env["FEATURES"] = " ".join(global_features)
+
+        if args.unmerge:
+            subprocess.run(unmerge_cmdline, env=env)
+
+        emerge_result = subprocess.run(emerge_cmdline, env=env)
+        print("")
+
+    return {
+        "use_flags": " ".join(job["use_flags"]),
+        "exit_code": emerge_result.returncode,
+        "features": portage.settings.get("FEATURES"),
+        "emerge_default_opts": portage.settings.get("EMERGE_DEFAULT_OPTS"),
+        "emerge_cmdline": " ".join(emerge_cmdline),
+        "test_feature_toggle": job["test_feature_toggle"],
+        "atom": job["cpv"],
+        "time": {
+            "started": time_started,
+            "finished": datetime.datetime.now().replace(microsecond=0).isoformat(),
+        },
+    }

--- a/pkg_testing_tools/tmp.py
+++ b/pkg_testing_tools/tmp.py
@@ -1,11 +1,4 @@
-import argparse
-import datetime
-import json
 import os
-import shlex
-import subprocess
-import sys
-from contextlib import ExitStack
 from tempfile import NamedTemporaryFile
 
 from .log import edebug, edie, eerror, einfo

--- a/pkg_testing_tools/tmp.py
+++ b/pkg_testing_tools/tmp.py
@@ -1,0 +1,30 @@
+import argparse
+import datetime
+import json
+import os
+import shlex
+import subprocess
+import sys
+from contextlib import ExitStack
+from tempfile import NamedTemporaryFile
+
+from .log import edebug, edie, eerror, einfo
+
+
+def get_etc_portage_tmp_file(directory_name, prefix):
+    target_location = os.path.join(prefix + "/etc/portage", directory_name)
+
+    if not os.path.isdir(target_location):
+        edie(
+            "The location {} needs to exist and be a directory".format(target_location)
+        )
+
+    handler = NamedTemporaryFile(
+        mode="w", prefix="zzz_pkg_testing_tool_", dir=target_location
+    )
+
+    umask = os.umask(0)
+    os.umask(umask)
+    os.chmod(handler.name, 0o644 & ~umask)
+
+    return handler


### PR DESCRIPTION
1. Allow for an ebuild to be passed with `-f`. It must be in a valid gentoo repository because of:
2. Temporary inject the path to the local repo in repos.conf.
3. Either `-p` or `f` has to be passed.
4. This direct testing of an ebuild will be integrated into https://github.com/APN-Pucky/pkgpr to **optionally** automatically test a PR before sending it.
5. Also moved some functions to individual files.