### PR TITLE
Ignore perl features prefix

### DIFF
--- a/pkg_testing_tools/use.py
+++ b/pkg_testing_tools/use.py
@@ -55,6 +55,7 @@ def filter_out_use_flags(flags):
         "kernel_",
         "l10n_",
         "linguas_",
+        "perl_features_",
         # "python_target_",
         # "python_targets_",
         # "ruby_targets_",

--- a/pkg_testing_tools/use.py
+++ b/pkg_testing_tools/use.py
@@ -48,17 +48,17 @@ def filter_out_use_flags(flags):
     new_flags = []
 
     ignore_flags_with_prefix = (
-        "elibc_",
-        "eglibc_",
-        "video_cards_",
-        "linguas_",
-        "l10n_",
-        "kernel_",
         "abi_",
+        "cpu_flags_",
+        "eglibc_",
+        "elibc_",
+        "kernel_",
+        "l10n_",
+        "linguas_",
         # "python_target_",
         # "python_targets_",
         # "ruby_targets_",
-        "cpu_flags_",
+        "video_cards_",
     )
 
     ignore_flags = set(["debug", "doc", "test", "selinux", "split-usr", "pic"])


### PR DESCRIPTION
 - perl_features_* will require a recompilation of all perl ecosystem,
   and generally it doesn't work at all for random use flag compilation.
   This should be controlled via tinderbox's own profile and ignored
   when using pkg-testing-tools.